### PR TITLE
Configure kind-cluster-creation workflows

### DIFF
--- a/.github/workflows/kind-cluster-creation.yml
+++ b/.github/workflows/kind-cluster-creation.yml
@@ -1,7 +1,8 @@
 name: Terratest Kind Cluster
 on:
-  workflow_dispatch:
   pull_request:
+      paths:
+        - k8s/clusters/kind
 jobs:
   go-tests:
     name: Run Kind Creation Cluster Tests


### PR DESCRIPTION
* Configure `kind-cluster-creation` workflows to run just when changes are made inside the directory `k8s/clusters/kind`.